### PR TITLE
Improve add card UX

### DIFF
--- a/src/app/arsenal/page.tsx
+++ b/src/app/arsenal/page.tsx
@@ -13,13 +13,14 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { FiSearch, FiPlus, FiFilter, FiEdit2, FiTrash2, FiDownload, FiUpload } from 'react-icons/fi';
+import { FiSearch, FiFilter, FiEdit2, FiTrash2, FiDownload, FiUpload } from 'react-icons/fi';
 import { format } from 'date-fns';
 import { usePhraseStore } from '@/stores/phrase.store';
 import { AddPhraseModal } from '@/components/UI/AddPhraseModal';
 import { EditPhraseModal } from '@/components/UI/EditPhraseModal';
 import { motion } from 'framer-motion';
 import { Phrase } from '@/types/models';
+import { FloatingAddButton } from '@/components/UI/FloatingAddButton';
 
 export default function ArsenalPage() {
   const { 
@@ -99,15 +100,7 @@ export default function ArsenalPage() {
           <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-100 mb-2">武器庫</h1>
           <p className="text-gray-600 dark:text-gray-400">すべてのフレーズを管理</p>
         </div>
-        <button
-          onClick={() => setIsAddModalOpen(true)}
-          className="px-6 py-3 bg-primary-600 text-white rounded-lg 
-                   hover:bg-primary-700 transition-colors flex items-center gap-2
-                   shadow-md hover:shadow-lg"
-        >
-          <FiPlus className="w-5 h-5" />
-          <span>フレーズを追加</span>
-        </button>
+        <div />
       </div>
 
       {/* 検索バーとアクション */}
@@ -138,15 +131,8 @@ export default function ArsenalPage() {
             <span className="hidden sm:inline">フィルター</span>
           </button>
 
-          {/* 追加ボタン */}
-          <button
-            onClick={() => setIsAddModalOpen(true)}
-            className="px-4 py-2 bg-primary-600 text-white rounded-lg 
-                     hover:bg-primary-700 transition-colors flex items-center gap-2"
-          >
-            <FiPlus className="w-5 h-5" />
-            <span className="hidden sm:inline">追加</span>
-          </button>
+          {/* スペース確保 */}
+          <div />
         </div>
 
         {/* フィルターオプション */}
@@ -300,11 +286,12 @@ export default function ArsenalPage() {
       </div>
 
       {/* フレーズ追加モーダル */}
-      <AddPhraseModal 
-        isOpen={isAddModalOpen} 
-        onClose={() => setIsAddModalOpen(false)} 
+      <AddPhraseModal
+        isOpen={isAddModalOpen}
+        onClose={() => setIsAddModalOpen(false)}
       />
-      
+      <FloatingAddButton onClick={() => setIsAddModalOpen(true)} />
+
       {/* フレーズ編集モーダル */}
       <EditPhraseModal
         isOpen={isEditModalOpen}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,11 +15,11 @@
 import { useState } from 'react';
 import { format } from 'date-fns';
 import { ja } from 'date-fns/locale';
-import { FiPlus } from 'react-icons/fi';
 import { usePhraseStore } from '@/stores/phrase.store';
 import { ReviewCard } from '@/components/Cards/ReviewCard';
 import { useAppInitializer } from '@/hooks/useAppInitializer';
 import { AddPhraseModal } from '@/components/UI/AddPhraseModal';
+import { FloatingAddButton } from '@/components/UI/FloatingAddButton';
 
 export default function HomePage() {
   const { isInitializing, initError } = useAppInitializer();
@@ -79,16 +79,8 @@ export default function HomePage() {
           )}
         </div>
 
-        {/* フレーズ追加ボタン */}
-        <button
-          onClick={() => setIsAddModalOpen(true)}
-          className="px-4 py-2 bg-primary-600 text-white rounded-lg 
-                   hover:bg-primary-700 transition-colors flex items-center gap-2
-                   shadow-md hover:shadow-lg"
-        >
-          <FiPlus className="w-5 h-5" />
-          <span className="hidden sm:inline">追加</span>
-        </button>
+        {/* スペース確保 */}
+        <div />
       </div>
 
       {/* メインコンテンツ */}
@@ -122,14 +114,16 @@ export default function HomePage() {
       )}
 
       {/* フレーズ追加モーダル */}
-      <AddPhraseModal 
-        isOpen={isAddModalOpen} 
+      <AddPhraseModal
+        isOpen={isAddModalOpen}
         onClose={() => {
           setIsAddModalOpen(false);
           // モーダルを閉じた後、今日のフレーズを再読み込み
           loadTodaysPhrases();
-        }} 
+        }}
       />
+      {/* 追加ボタン */}
+      <FloatingAddButton onClick={() => setIsAddModalOpen(true)} />
     </div>
   );
 }

--- a/src/components/UI/AddPhraseModal.tsx
+++ b/src/components/UI/AddPhraseModal.tsx
@@ -314,10 +314,10 @@ export function AddPhraseModal({ isOpen, onClose }: AddPhraseModalProps) {
                   </button>
                   <button
                     type="submit"
-                    className="flex-1 px-4 py-2 bg-primary-600 text-white rounded-lg 
+                    className="flex-1 px-4 py-2 bg-primary-600 text-white rounded-lg
                              hover:bg-primary-700 transition-colors"
                   >
-                    追加する
+                    作成完了
                   </button>
                 </div>
               </form>

--- a/src/components/UI/FloatingAddButton.tsx
+++ b/src/components/UI/FloatingAddButton.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { FiPlus } from 'react-icons/fi';
+
+interface FloatingAddButtonProps {
+  onClick: () => void;
+  ariaLabel?: string;
+}
+
+export function FloatingAddButton({ onClick, ariaLabel = '新しいカードを追加' }: FloatingAddButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className="fixed bottom-4 right-4 md:bottom-8 md:right-8 z-40 p-4 rounded-full bg-primary-600 text-white shadow-lg hover:bg-primary-700"
+      aria-label={ariaLabel}
+    >
+      <FiPlus className="w-6 h-6" />
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add FloatingAddButton component
- use FloatingAddButton in Home and Arsenal pages
- rename submit text in AddPhraseModal to `作成完了`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606acec54c8330a67ebf406404de2f